### PR TITLE
fixed react-tap-event-plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "redux": "^3.5.2",
     "redux-act": "^0.4.0",
     "redux-logger": "^2.6.1",


### PR DESCRIPTION
fixed react-tap-event-plugin version, with 15.4.2 compatibles only 2.0.* verison of react-tap-event-plugin
`ERROR in ./~/react-tap-event-plugin/src/TapEventPlugin.js
Module not found: Error: Cannot resolve module 'react/lib/SyntheticUIEvent' in ../node_modules/react-tap-event-plugin/src
 @ ./~/react-tap-event-plugin/src/TapEventPlugin.js 25:23-60`

